### PR TITLE
初回レンダリングでCSSの反映が遅いのを直す

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,13 @@
 {
   "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssg": true }]]
+  "plugins": [
+    [
+      "styled-components",
+      {
+        "ssr": true,
+        "displayName": true,
+        "preprocess": false
+      }
+    ]
+  ]
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,25 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheet } from 'styled-components';
+
+export default class MyDocument extends Document {
+  static getInitialProps({ renderPage }) {
+    const sheet = new ServerStyleSheet();
+    const page = renderPage(
+      (App) => (props) => sheet.collectStyles(<App {...props} />)
+    );
+    const styleTags = sheet.getStyleElement();
+    return { ...page, styleTags };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>{this.props.styleTags}</Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}


### PR DESCRIPTION
## やったこと
- styled-componentsで生成されるCSSをheadタグの中で読み込むようにした
- .babelrcの修正

## 参考
issueを参照